### PR TITLE
Add support for environment variables in config.pb.json strings

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -139,3 +139,8 @@ maven_jar(
   name = "google_gson_artifact",
   artifact = "com.google.code.gson:gson:2.6.2",
 )
+
+maven_jar(
+  name = "apache_commons_lang3_artifact",
+  artifact = "org.apache.commons:commons-lang3:3.4",
+)

--- a/src/main/java/me/dinowernli/grpc/polyglot/config/BUILD
+++ b/src/main/java/me/dinowernli/grpc/polyglot/config/BUILD
@@ -7,6 +7,7 @@ java_library(
     "//src/main/proto:config_proto",
     "//src/main/java/me/dinowernli/grpc/polyglot/protobuf",
     "//third_party/args4j",
+    "//third_party/commons-lang",
     "//third_party/grpc",
     "//third_party/guava",
     "//third_party/netty",

--- a/third_party/commons-lang/BUILD
+++ b/third_party/commons-lang/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+  name = "commons-lang",
+  exports = [
+    "@apache_commons_lang3_artifact//jar",
+  ],
+  licenses = ["permissive"],
+)


### PR DESCRIPTION
This is a bit YOLO; it works for me, but happy to hear suggestions for improvements.
