### PR TITLE
Use new version.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -166,7 +166,7 @@ maven_jar(
 git_repository(
   name = "autotest",
   remote = "https://github.com/dinowernli/bazel-junit-autotest.git",
-  commit = "202954e",
+  commit = "da9ffdb73841fe14459a7eec36bcd84c12e1ac53",
 )
 
 load("@autotest//bzl:autotest.bzl", "autotest_junit_repo")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -166,7 +166,7 @@ maven_jar(
 git_repository(
   name = "autotest",
   remote = "https://github.com/dinowernli/bazel-junit-autotest.git",
-  commit = "da9ffdb73841fe14459a7eec36bcd84c12e1ac53",
+  tag = "v0.0.1",
 )
 
 load("@autotest//bzl:autotest.bzl", "autotest_junit_repo")


### PR DESCRIPTION
Before:

```
bazel test ...
INFO: Found 43 targets and 8 test targets...
INFO: Elapsed time: 26.451s, Critical Path: 23.76s
//src/test/java/me/dinowernli/grpc/polyglot/command:tests                PASSED in 6.1s
//src/test/java/me/dinowernli/grpc/polyglot/config:tests                 PASSED in 5.1s
//src/test/java/me/dinowernli/grpc/polyglot/grpc:tests                   PASSED in 6.2s
//src/test/java/me/dinowernli/grpc/polyglot/integration:plain            PASSED in 9.4s
//src/test/java/me/dinowernli/grpc/polyglot/integration:tls              PASSED in 9.3s
//src/test/java/me/dinowernli/grpc/polyglot/io:tests                     PASSED in 4.9s
//src/test/java/me/dinowernli/grpc/polyglot/oauth2:tests                 PASSED in 3.9s
//src/test/java/me/dinowernli/grpc/polyglot/protobuf:tests               PASSED in 4.6s
```

After:

```
bazel test ...
INFO: Found 43 targets and 8 test targets...
INFO: Elapsed time: 15.910s, Critical Path: 12.97s
//src/test/java/me/dinowernli/grpc/polyglot/command:tests                PASSED in 1.1s
//src/test/java/me/dinowernli/grpc/polyglot/config:tests                 PASSED in 1.2s
//src/test/java/me/dinowernli/grpc/polyglot/grpc:tests                   PASSED in 0.6s
//src/test/java/me/dinowernli/grpc/polyglot/integration:plain            PASSED in 6.5s
//src/test/java/me/dinowernli/grpc/polyglot/integration:tls              PASSED in 4.4s
//src/test/java/me/dinowernli/grpc/polyglot/io:tests                     PASSED in 0.9s
//src/test/java/me/dinowernli/grpc/polyglot/oauth2:tests                 PASSED in 0.8s
//src/test/java/me/dinowernli/grpc/polyglot/protobuf:tests               PASSED in 1.2s
```