### PR TITLE
Adds support for resolving called services by reflection

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,6 +95,11 @@ maven_jar(
 )
 
 maven_jar(
+  name = "grpc_services_artifact",
+  artifact = "io.grpc:grpc-services:1.4.0",
+)
+
+maven_jar(
   name = "grpc_stub_artifact",
   artifact = "io.grpc:grpc-stub:1.4.0",
 )

--- a/src/main/java/me/dinowernli/grpc/polyglot/Main.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/Main.java
@@ -49,8 +49,6 @@ public class Main {
         : configLoader.getDefaultConfiguration();
     logger.info("Loaded configuration: " + config.getName());
 
-    FileDescriptorSet fileDescriptorSet = getFileDescriptorSet(config.getProtoConfig());
-
     String command;
     if (arguments.command().isPresent()) {
       command = arguments.command().get();
@@ -62,6 +60,7 @@ public class Main {
     try(Output commandLineOutput = Output.forConfiguration(config.getOutputConfig())) {
       switch (command) {
         case CommandLineArgs.LIST_SERVICES_COMMAND:
+          FileDescriptorSet fileDescriptorSet = getFileDescriptorSet(config.getProtoConfig());
           ServiceList.listServices(
               commandLineOutput,
               fileDescriptorSet, config.getProtoConfig().getProtoDiscoveryRoot(),
@@ -71,7 +70,7 @@ public class Main {
         case CommandLineArgs.CALL_COMMAND:
           ServiceCall.callEndpoint(
               commandLineOutput,
-              fileDescriptorSet,
+              config.getProtoConfig(),
               arguments.endpoint(),
               arguments.fullMethod(),
               arguments.protoDiscoveryRoot(),

--- a/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
@@ -69,8 +69,12 @@ public class ServiceCall {
 
     // Fetch the appropriate file descriptors for the service.
     final FileDescriptorSet fileDescriptorSet;
-    Optional<FileDescriptorSet> reflectionDescriptors =
-        resolveServiceByReflection(channel, grpcMethodName.getFullServiceName());
+    Optional<FileDescriptorSet> reflectionDescriptors = Optional.empty();
+    if (protoConfig.getUseReflection()) {
+      reflectionDescriptors =
+          resolveServiceByReflection(channel, grpcMethodName.getFullServiceName());
+    }
+
     if (reflectionDescriptors.isPresent()) {
       logger.info("Using proto descriptors fetched by reflection");
       fileDescriptorSet = reflectionDescriptors.get();

--- a/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
@@ -75,9 +75,19 @@ public class ServiceCall {
     try {
       ImmutableList<String> services = serverReflectionClient.listServices().get();
       logger.error(">>>>> services: " + services);
+
+      logger.error(">>>>>>>>>>> RESOLVING");
+      FileDescriptorSet descriptors = serverReflectionClient.lookupService(services.get(0)).get();
     } catch (Throwable t) {
       logger.error(">>>>> error listing services", t);
     }
+
+
+
+
+
+
+
 
     ImmutableList<DynamicMessage> requestMessages =
         MessageReader.forStdin(methodDescriptor.getInputType()).read();

--- a/src/main/java/me/dinowernli/grpc/polyglot/config/CommandLineArgs.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/config/CommandLineArgs.java
@@ -56,6 +56,9 @@ public class CommandLineArgs {
   @Option(name = "--tls_client_override_authority", metaVar = "<host>")
   private String tlsClientOverrideAuthority;
 
+  @Option(name = "--use_reflection", metaVar = "true|false")
+  private String useReflection;
+
   @Option(name = "--help")
   private Boolean help;
 
@@ -172,6 +175,11 @@ public class CommandLineArgs {
 
   public Optional<String> tlsClientOverrideAuthority() {
     return Optional.ofNullable(tlsClientOverrideAuthority);
+  }
+
+  /** Defaults to true. */
+  public boolean useReflection() {
+    return useReflection == null || useReflection.equals("true");
   }
 
   /**

--- a/src/main/java/me/dinowernli/grpc/polyglot/config/ConfigurationLoader.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/config/ConfigurationLoader.java
@@ -105,6 +105,9 @@ public class ConfigurationLoader {
     }
 
     Configuration.Builder resultBuilder = configuration.toBuilder();
+
+    resultBuilder.getProtoConfigBuilder().setUseReflection(overrides.get().useReflection());
+
     if (overrides.get().useTls().isPresent()) {
       resultBuilder.getCallConfigBuilder().setUseTls(overrides.get().useTls().get());
     }

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ChannelFactory.java
@@ -1,0 +1,72 @@
+package me.dinowernli.grpc.polyglot.grpc;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.net.ssl.SSLException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.net.HostAndPort;
+import io.grpc.Channel;
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import polyglot.ConfigProto;
+
+/** Knows how to construct grpc channels. */
+public class ChannelFactory {
+  private ConfigProto.CallConfiguration callConfiguration;
+
+  public ChannelFactory(ConfigProto.CallConfiguration callConfiguration) {
+    this.callConfiguration = callConfiguration;
+  }
+
+  public Channel createChannel(HostAndPort endpoint) {
+    if (!callConfiguration.getUseTls()) {
+      return createPlaintextChannel(endpoint);
+    }
+    NettyChannelBuilder nettyChannelBuilder =
+        NettyChannelBuilder.forAddress(endpoint.getHostText(), endpoint.getPort())
+            .sslContext(createSslContext())
+            .negotiationType(NegotiationType.TLS);
+
+    if (!callConfiguration.getTlsClientOverrideAuthority().isEmpty()) {
+      nettyChannelBuilder.overrideAuthority(callConfiguration.getTlsClientOverrideAuthority());
+    }
+
+    return nettyChannelBuilder.build();
+  }
+
+  private static Channel createPlaintextChannel(HostAndPort endpoint) {
+    return NettyChannelBuilder.forAddress(endpoint.getHostText(), endpoint.getPort())
+        .negotiationType(NegotiationType.PLAINTEXT)
+        .build();
+  }
+
+  private SslContext createSslContext() {
+    SslContextBuilder resultBuilder = GrpcSslContexts.forClient();
+    if (!callConfiguration.getTlsCaCertPath().isEmpty()) {
+      resultBuilder.trustManager(loadFile(callConfiguration.getTlsCaCertPath()));
+    }
+    if (!callConfiguration.getTlsClientCertPath().isEmpty()) {
+      resultBuilder.keyManager(
+          loadFile(callConfiguration.getTlsClientCertPath()),
+          loadFile(callConfiguration.getTlsClientKeyPath()));
+    }
+    try {
+      return resultBuilder.build();
+    } catch (SSLException e) {
+      throw new RuntimeException("Unable to build sslcontext for client call", e);
+    }
+  }
+
+  private static File loadFile(String fileName) {
+    Path filePath = Paths.get(fileName);
+    Preconditions.checkArgument(Files.exists(filePath), "File " + fileName + " was not found");
+    return filePath.toFile();
+  }
+}

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/DynamicGrpcClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/DynamicGrpcClient.java
@@ -113,6 +113,13 @@ public class DynamicGrpcClient {
     }
   }
 
+  /** Returns the {@link Channel} used by this client. */
+  public Channel getChannel() {
+    // TODO(dino): This should not expose its channel. Instead, the callers of this method should
+    // just be created with the same channel as is passed into here.
+    return channel;
+  }
+
   private ListenableFuture<Void> callBidiStreaming(
       ImmutableList<DynamicMessage> requests,
       StreamObserver<DynamicMessage> responseObserver,

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/DynamicGrpcClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/DynamicGrpcClient.java
@@ -3,7 +3,6 @@ package me.dinowernli.grpc.polyglot.grpc;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 
-import com.google.auth.Credentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -17,9 +16,7 @@ import com.google.protobuf.DynamicMessage;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
-import io.grpc.ClientInterceptors;
 import io.grpc.MethodDescriptor.MethodType;
-import io.grpc.auth.ClientAuthInterceptor;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
 import me.dinowernli.grpc.polyglot.protobuf.DynamicMessageMarshaller;
@@ -36,21 +33,6 @@ public class DynamicGrpcClient {
   /** Creates a client for the supplied method, talking to the supplied endpoint. */
   public static DynamicGrpcClient create(MethodDescriptor protoMethod, Channel channel) {
     return new DynamicGrpcClient(protoMethod, channel, createExecutorService());
-  }
-
-  /**
-   * Creates a client for the supplied method, talking to the supplied endpoint. Passes the
-   * supplied credentials on every rpc call.
-   */
-  public static DynamicGrpcClient createWithCredentials(
-      MethodDescriptor protoMethod,
-      Channel channel,
-      Credentials credentials) {
-    ListeningExecutorService executor = createExecutorService();
-    return new DynamicGrpcClient(
-        protoMethod,
-        ClientInterceptors.intercept(channel, new ClientAuthInterceptor(credentials, executor)),
-        executor);
   }
 
   @VisibleForTesting

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
@@ -176,7 +176,7 @@ public class ServerReflectionClient {
         return;
       }
 
-      logger.info("Retrieved file descriptor: " + fileDescriptor.getName());
+      logger.debug("Retrieved file descriptor: " + fileDescriptor.getName());
       fileDescriptors.put(fileDescriptor.getName(), fileDescriptor);
       fileDescriptor.getDependencyList().forEach(dep -> {
         if (!fileDescriptors.containsKey(dep)) {
@@ -187,6 +187,7 @@ public class ServerReflectionClient {
 
       --outstandingRequests;
       if (outstandingRequests == 0) {
+        logger.debug("Retrieved service definition for [{}] by reflection", serviceName);
         resultFuture.set(FileDescriptorSet.newBuilder()
             .addAllFile(fileDescriptors.values())
             .build());

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
@@ -1,10 +1,15 @@
 package me.dinowernli.grpc.polyglot.grpc;
 
-import java.util.HashSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import io.grpc.Channel;
 import io.grpc.reflection.v1alpha.ListServiceResponse;
 import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
@@ -17,50 +22,55 @@ import org.slf4j.LoggerFactory;
 
 public class ServerReflectionClient {
   private static final Logger logger = LoggerFactory.getLogger(ServerReflectionClient.class);
+  private static final long RPC_DEADLINE_MS = 5_000;
   private static final ServerReflectionRequest LIST_SERVICES_REQUEST =
       ServerReflectionRequest.newBuilder()
           .setListServices("")  // Note sure what this is for, appears to be ignored.
           .build();
 
-  private final StreamObserver<ServerReflectionRequest> requestStream;
-  private final ResponseObserver responseStream;
+  private final Channel channel;
+  private final ExecutorService executor;
 
   /** Returns a new reflection client using the supplied channel. */
   public static ServerReflectionClient create(Channel channel) {
-    ResponseObserver responseStream = new ResponseObserver();
-    StreamObserver<ServerReflectionRequest> requestStream =
-        ServerReflectionGrpc.newStub(channel).serverReflectionInfo(responseStream);
-    return new ServerReflectionClient(requestStream, responseStream);
+    return new ServerReflectionClient(channel, Executors.newCachedThreadPool());
   }
 
-  private ServerReflectionClient(
-      StreamObserver<ServerReflectionRequest> requestStream,
-      ResponseObserver responseStream) {
-    this.requestStream = requestStream;
-    this.responseStream = responseStream;
+  private ServerReflectionClient(Channel channel, ExecutorService executor) {
+    this.channel = channel;
+    this.executor = executor;
   }
 
   /** Asks the remote server to list its services and completes when the server responds. */
   public ListenableFuture<ImmutableList<String>> listServices() {
-    SettableFuture<ImmutableList<String>> resultFuture = SettableFuture.create();
-    responseStream.addServiceListFuture(resultFuture);
+    ResponseObserver responseStream = new ResponseObserver();
+    StreamObserver<ServerReflectionRequest> requestStream = ServerReflectionGrpc.newStub(channel)
+        .withDeadlineAfter(RPC_DEADLINE_MS, TimeUnit.MILLISECONDS)
+        .serverReflectionInfo(responseStream);
     requestStream.onNext(LIST_SERVICES_REQUEST);
-    return resultFuture;
+
+    ListenableFuture<ImmutableList<String>> result = responseStream.resultFuture();
+    Futures.addCallback(result, new RpcCompletingFutureCallback<>(requestStream), executor);
+    return result;
+  }
+
+  /**
+   * Returns a {@link FileDescriptorSet} containing all the transitive dependencies of the supplied
+   * service, as provided by the remote server.
+   */
+  public ListenableFuture<FileDescriptorSet> lookupService(String serviceName) {
+    throw new UnsupportedOperationException();
   }
 
   private static class ResponseObserver implements StreamObserver<ServerReflectionResponse> {
-    private final Object responseLock;
-    private volatile HashSet<SettableFuture<ImmutableList<String>>> listServicesFutures;
+    private final SettableFuture<ImmutableList<String>> resultFuture;
 
     private ResponseObserver() {
-      this.responseLock = new Object();
-      this.listServicesFutures = new HashSet<>();
+      resultFuture = SettableFuture.create();
     }
 
-    public void addServiceListFuture(SettableFuture<ImmutableList<String>> future) {
-      synchronized (responseLock) {
-        listServicesFutures.add(future);
-      }
+    private ListenableFuture<ImmutableList<String>> resultFuture() {
+      return resultFuture;
     }
 
     @Override
@@ -79,26 +89,37 @@ public class ServerReflectionClient {
     @Override
     public void onError(Throwable t) {
       logger.error("Error in the server reflection rpc", t);
+      resultFuture.setException(t);
     }
 
     @Override
     public void onCompleted() {
       logger.error("Unexpected completion of the server reflection rpc");
+      resultFuture.setException(new RuntimeException("Unexpected end of rpc"));
     }
 
     private void handleListServiceRespones(ListServiceResponse response) {
-      // Construct the resulting list of services.
       ImmutableList.Builder<String> servicesBuilder = ImmutableList.builder();
       response.getServiceList().forEach(service -> servicesBuilder.add(service.getName()));
-      ImmutableList<String> services = servicesBuilder.build();
+      resultFuture.set(servicesBuilder.build());
+    }
+  }
 
-      // Snapshot the list of promises and resolve them all.
-      HashSet<SettableFuture<ImmutableList<String>>> promises = null;
-      synchronized (responseLock) {
-        promises = listServicesFutures;
-        listServicesFutures = new HashSet<>();
-      }
-      promises.forEach(future -> future.set(services));
+  private static class RpcCompletingFutureCallback<T> implements FutureCallback<T> {
+    private final StreamObserver<?> requestStream;
+
+    private RpcCompletingFutureCallback(StreamObserver<?> requestStream) {
+      this.requestStream = requestStream;
+    }
+
+    @Override
+    public void onSuccess(Object o) {
+      requestStream.onCompleted();
+    }
+
+    @Override
+    public void onFailure(Throwable throwable) {
+      requestStream.onCompleted();
     }
   }
 }

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
@@ -1,15 +1,15 @@
 package me.dinowernli.grpc.polyglot.grpc;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.Channel;
 import io.grpc.reflection.v1alpha.ListServiceResponse;
 import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
@@ -22,36 +22,31 @@ import org.slf4j.LoggerFactory;
 
 public class ServerReflectionClient {
   private static final Logger logger = LoggerFactory.getLogger(ServerReflectionClient.class);
-  private static final long RPC_DEADLINE_MS = 5_000;
+  private static final long LIST_RPC_DEADLINE_MS = 1_000;
+  private static final long LOOKUP_RPC_DEADLINE_MS = 10_000;
   private static final ServerReflectionRequest LIST_SERVICES_REQUEST =
       ServerReflectionRequest.newBuilder()
           .setListServices("")  // Note sure what this is for, appears to be ignored.
           .build();
 
   private final Channel channel;
-  private final ExecutorService executor;
 
   /** Returns a new reflection client using the supplied channel. */
   public static ServerReflectionClient create(Channel channel) {
-    return new ServerReflectionClient(channel, Executors.newCachedThreadPool());
+    return new ServerReflectionClient(channel);
   }
 
-  private ServerReflectionClient(Channel channel, ExecutorService executor) {
+  private ServerReflectionClient(Channel channel) {
     this.channel = channel;
-    this.executor = executor;
   }
 
   /** Asks the remote server to list its services and completes when the server responds. */
   public ListenableFuture<ImmutableList<String>> listServices() {
-    ResponseObserver responseStream = new ResponseObserver();
+    ListServicesHandler rpcHandler = new ListServicesHandler();
     StreamObserver<ServerReflectionRequest> requestStream = ServerReflectionGrpc.newStub(channel)
-        .withDeadlineAfter(RPC_DEADLINE_MS, TimeUnit.MILLISECONDS)
-        .serverReflectionInfo(responseStream);
-    requestStream.onNext(LIST_SERVICES_REQUEST);
-
-    ListenableFuture<ImmutableList<String>> result = responseStream.resultFuture();
-    Futures.addCallback(result, new RpcCompletingFutureCallback<>(requestStream), executor);
-    return result;
+        .withDeadlineAfter(LIST_RPC_DEADLINE_MS, TimeUnit.MILLISECONDS)
+        .serverReflectionInfo(rpcHandler);
+    return rpcHandler.start(requestStream);
   }
 
   /**
@@ -59,17 +54,26 @@ public class ServerReflectionClient {
    * service, as provided by the remote server.
    */
   public ListenableFuture<FileDescriptorSet> lookupService(String serviceName) {
-    throw new UnsupportedOperationException();
+    LookupServiceHandler rpcHandler = new LookupServiceHandler(serviceName);
+    StreamObserver<ServerReflectionRequest> requestStream = ServerReflectionGrpc.newStub(channel)
+        .withDeadlineAfter(LOOKUP_RPC_DEADLINE_MS, TimeUnit.MILLISECONDS)
+        .serverReflectionInfo(rpcHandler);
+    return rpcHandler.start(requestStream);
   }
 
-  private static class ResponseObserver implements StreamObserver<ServerReflectionResponse> {
+  /** Handles the rpc life cycle of a single list operation. */
+  private static class ListServicesHandler implements StreamObserver<ServerReflectionResponse> {
     private final SettableFuture<ImmutableList<String>> resultFuture;
+    private StreamObserver<ServerReflectionRequest> requestStream;
 
-    private ResponseObserver() {
+    private ListServicesHandler() {
       resultFuture = SettableFuture.create();
     }
 
-    private ListenableFuture<ImmutableList<String>> resultFuture() {
+    ListenableFuture<ImmutableList<String>> start(
+        StreamObserver<ServerReflectionRequest> requestStream) {
+      this.requestStream = requestStream;
+      requestStream.onNext(LIST_SERVICES_REQUEST);
       return resultFuture;
     }
 
@@ -102,24 +106,100 @@ public class ServerReflectionClient {
       ImmutableList.Builder<String> servicesBuilder = ImmutableList.builder();
       response.getServiceList().forEach(service -> servicesBuilder.add(service.getName()));
       resultFuture.set(servicesBuilder.build());
+      requestStream.onCompleted();
     }
   }
 
-  private static class RpcCompletingFutureCallback<T> implements FutureCallback<T> {
-    private final StreamObserver<?> requestStream;
+  /** Handles the rpc life cycle of a single lookup operation. */
+  private static class LookupServiceHandler implements StreamObserver<ServerReflectionResponse> {
+    private final SettableFuture<FileDescriptorSet> resultFuture;
+    private final String serviceName;
+    private StreamObserver<ServerReflectionRequest> requestStream;
+    private HashMap<String, FileDescriptorProto> fileDescriptors;
 
-    private RpcCompletingFutureCallback(StreamObserver<?> requestStream) {
+    // Used to notice when we've received all the files we've asked for and we can end the rpc.
+    private int outstandingRequests;
+
+    private LookupServiceHandler(String serviceName) {
+      this.serviceName = serviceName;
+      this.resultFuture = SettableFuture.create();
+      this.fileDescriptors = new HashMap<>();
+      this.outstandingRequests = 0;
+    }
+
+    ListenableFuture<FileDescriptorSet> start(
+        StreamObserver<ServerReflectionRequest> requestStream) {
       this.requestStream = requestStream;
+      requestStream.onNext(requestForSymbol(serviceName));
+      ++outstandingRequests;
+      return resultFuture;
     }
 
     @Override
-    public void onSuccess(Object o) {
-      requestStream.onCompleted();
+    public void onNext(ServerReflectionResponse response) {
+      MessageResponseCase responseCase = response.getMessageResponseCase();
+      switch (responseCase) {
+        case FILE_DESCRIPTOR_RESPONSE:
+          response.getFileDescriptorResponse().getFileDescriptorProtoList()
+              .forEach(this::handleFileDescriptor);
+          break;
+        default:
+          logger.warn("Got unknown reflection response type: " + responseCase);
+          break;
+      }
     }
 
     @Override
-    public void onFailure(Throwable throwable) {
-      requestStream.onCompleted();
+    public void onError(Throwable t) {
+      logger.error("Error in the server reflection rpc", t);
+      resultFuture.setException(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      logger.error("Unexpected completion of the server reflection rpc");
+      resultFuture.setException(new RuntimeException("Unexpected end of rpc"));
+    }
+
+    private void handleFileDescriptor(ByteString fileDescriptorBytes) {
+      FileDescriptorProto fileDescriptor;
+      try {
+        fileDescriptor = FileDescriptorProto.newBuilder()
+            .mergeFrom(fileDescriptorBytes)
+            .build();
+      } catch (InvalidProtocolBufferException e) {
+        logger.warn("Failed to parse bytes as file descriptor proto");
+        return;
+      }
+
+      logger.info("Retrieved file descriptor: " + fileDescriptor.getName());
+      fileDescriptors.put(fileDescriptor.getName(), fileDescriptor);
+      fileDescriptor.getDependencyList().forEach(dep -> {
+        if (!fileDescriptors.containsKey(dep)) {
+          requestStream.onNext(requestForDescriptor(dep));
+          ++outstandingRequests;
+        }
+      });
+
+      --outstandingRequests;
+      if (outstandingRequests == 0) {
+        resultFuture.set(FileDescriptorSet.newBuilder()
+            .addAllFile(fileDescriptors.values())
+            .build());
+        requestStream.onCompleted();
+      }
+    }
+
+    private static ServerReflectionRequest requestForDescriptor(String name) {
+      return ServerReflectionRequest.newBuilder()
+          .setFileByFilename(name)
+          .build();
+    }
+
+    private static ServerReflectionRequest requestForSymbol(String symbol) {
+      return ServerReflectionRequest.newBuilder()
+          .setFileContainingSymbol(symbol)
+          .build();
     }
   }
 }

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
@@ -185,7 +185,7 @@ public class ServerReflectionClient {
     }
 
     private void processDependencies(FileDescriptorProto fileDescriptor) {
-      logger.info("Processing deps of descriptor: " + fileDescriptor.getName());
+      logger.debug("Processing deps of descriptor: " + fileDescriptor.getName());
       fileDescriptor.getDependencyList().forEach(dep -> {
         if (!resolvedDescriptors.containsKey(dep) && !requestedDescriptors.contains(dep)) {
           requestedDescriptors.add(dep);

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
@@ -1,0 +1,104 @@
+package me.dinowernli.grpc.polyglot.grpc;
+
+import java.util.HashSet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.grpc.Channel;
+import io.grpc.reflection.v1alpha.ListServiceResponse;
+import io.grpc.reflection.v1alpha.ServerReflectionGrpc;
+import io.grpc.reflection.v1alpha.ServerReflectionRequest;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse;
+import io.grpc.reflection.v1alpha.ServerReflectionResponse.MessageResponseCase;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServerReflectionClient {
+  private static final Logger logger = LoggerFactory.getLogger(ServerReflectionClient.class);
+  private static final ServerReflectionRequest LIST_SERVICES_REQUEST =
+      ServerReflectionRequest.newBuilder()
+          .setListServices("")  // Note sure what this is for, appears to be ignored.
+          .build();
+
+  private final StreamObserver<ServerReflectionRequest> requestStream;
+  private final ResponseObserver responseStream;
+
+  /** Returns a new reflection client using the supplied channel. */
+  public static ServerReflectionClient create(Channel channel) {
+    ResponseObserver responseStream = new ResponseObserver();
+    StreamObserver<ServerReflectionRequest> requestStream =
+        ServerReflectionGrpc.newStub(channel).serverReflectionInfo(responseStream);
+    return new ServerReflectionClient(requestStream, responseStream);
+  }
+
+  private ServerReflectionClient(
+      StreamObserver<ServerReflectionRequest> requestStream,
+      ResponseObserver responseStream) {
+    this.requestStream = requestStream;
+    this.responseStream = responseStream;
+  }
+
+  /** Asks the remote server to list its services and completes when the server responds. */
+  public ListenableFuture<ImmutableList<String>> listServices() {
+    SettableFuture<ImmutableList<String>> resultFuture = SettableFuture.create();
+    responseStream.addServiceListFuture(resultFuture);
+    requestStream.onNext(LIST_SERVICES_REQUEST);
+    return resultFuture;
+  }
+
+  private static class ResponseObserver implements StreamObserver<ServerReflectionResponse> {
+    private final Object responseLock;
+    private volatile HashSet<SettableFuture<ImmutableList<String>>> listServicesFutures;
+
+    private ResponseObserver() {
+      this.responseLock = new Object();
+      this.listServicesFutures = new HashSet<>();
+    }
+
+    public void addServiceListFuture(SettableFuture<ImmutableList<String>> future) {
+      synchronized (responseLock) {
+        listServicesFutures.add(future);
+      }
+    }
+
+    @Override
+    public void onNext(ServerReflectionResponse serverReflectionResponse) {
+      MessageResponseCase responseCase = serverReflectionResponse.getMessageResponseCase();
+      switch (responseCase) {
+        case LIST_SERVICES_RESPONSE:
+          handleListServiceRespones(serverReflectionResponse.getListServicesResponse());
+          break;
+        default:
+          logger.warn("Got unknown reflection response type: " + responseCase);
+          break;
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      logger.error("Error in the server reflection rpc", t);
+    }
+
+    @Override
+    public void onCompleted() {
+      logger.error("Unexpected completion of the server reflection rpc");
+    }
+
+    private void handleListServiceRespones(ListServiceResponse response) {
+      // Construct the resulting list of services.
+      ImmutableList.Builder<String> servicesBuilder = ImmutableList.builder();
+      response.getServiceList().forEach(service -> servicesBuilder.add(service.getName()));
+      ImmutableList<String> services = servicesBuilder.build();
+
+      // Snapshot the list of promises and resolve them all.
+      HashSet<SettableFuture<ImmutableList<String>>> promises = null;
+      synchronized (responseLock) {
+        promises = listServicesFutures;
+        listServicesFutures = new HashSet<>();
+      }
+      promises.forEach(future -> future.set(services));
+    }
+  }
+}

--- a/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/grpc/ServerReflectionClient.java
@@ -98,8 +98,10 @@ public class ServerReflectionClient {
 
     @Override
     public void onCompleted() {
-      logger.error("Unexpected completion of the server reflection rpc");
-      resultFuture.setException(new RuntimeException("Unexpected end of rpc"));
+      if (!resultFuture.isDone()) {
+        logger.error("Unexpected completion of the server reflection rpc");
+        resultFuture.setException(new RuntimeException("Unexpected end of rpc"));
+      }
     }
 
     private void handleListServiceRespones(ListServiceResponse response) {
@@ -157,8 +159,10 @@ public class ServerReflectionClient {
 
     @Override
     public void onCompleted() {
-      logger.error("Unexpected completion of the server reflection rpc");
-      resultFuture.setException(new RuntimeException("Unexpected end of rpc"));
+      if (!resultFuture.isDone()) {
+        logger.error("Unexpected completion of the server reflection rpc");
+        resultFuture.setException(new RuntimeException("Unexpected end of rpc"));
+      }
     }
 
     private void handleFileDescriptor(ByteString fileDescriptorBytes) {

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtoMethodName.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtoMethodName.java
@@ -1,5 +1,7 @@
 package me.dinowernli.grpc.polyglot.protobuf;
 
+import com.google.common.base.Joiner;
+
 /** Represents a full grpc method, including package, service and method names. */
 public class ProtoMethodName {
   // TODO(dino): Use autovalue for this class.
@@ -53,6 +55,11 @@ public class ProtoMethodName {
   /** Returns the (unqualified) service name of the method. */
   public String getServiceName() {
     return serviceName;
+  }
+
+  /** Returns the fully qualified service name of the method. */
+  public String getFullServiceName() {
+    return Joiner.on(".").join(packageName, serviceName);
   }
 
   /** Returns the (unqualified) method name of the method. */

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolver.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolver.java
@@ -22,11 +22,6 @@ public class ServiceResolver {
   private static final Logger logger = LoggerFactory.getLogger(ServiceResolver.class);
   private final ImmutableList<FileDescriptor> fileDescriptors;
 
-  /** Creates a resolver which searches the supplied file descriptors. */
-  public static ServiceResolver fromFileDescriptors(FileDescriptor... descriptors) {
-    return new ServiceResolver(Arrays.asList(descriptors));
-  }
-
   /** Creates a resolver which searches the supplied {@link FileDescriptorSet}. */
   public static ServiceResolver fromFileDescriptorSet(FileDescriptorSet descriptorSet) {
     ImmutableMap<String, FileDescriptorProto> descriptorProtoIndex =

--- a/src/main/java/me/dinowernli/grpc/polyglot/server/Main.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/server/Main.java
@@ -3,6 +3,7 @@ package me.dinowernli.grpc.polyglot.server;
 import java.io.IOException;
 
 import io.grpc.ServerBuilder;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,7 +19,7 @@ public class Main {
     try {
       ServerBuilder.forPort(SERVER_PORT)
           .addService(new HelloServiceImpl())
-          .addService(io.grpc.protobuf.services.ProtoReflectionService.newInstance())
+          .addService(ProtoReflectionService.newInstance())
           .build()
           .start()
           .awaitTermination();

--- a/src/main/java/me/dinowernli/grpc/polyglot/server/Main.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/server/Main.java
@@ -18,6 +18,7 @@ public class Main {
     try {
       ServerBuilder.forPort(SERVER_PORT)
           .addService(new HelloServiceImpl())
+          .addService(io.grpc.protobuf.services.ProtoReflectionService.newInstance())
           .build()
           .start()
           .awaitTermination();

--- a/src/main/java/me/dinowernli/grpc/polyglot/testing/TestServer.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/testing/TestServer.java
@@ -9,6 +9,7 @@ import com.google.common.base.Throwables;
 import io.grpc.Server;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
@@ -125,7 +126,9 @@ public class TestServer {
       int port,
       TestServiceImplBase testService,
       Optional<SslContext> sslContext) throws IOException {
-    NettyServerBuilder serverBuilder = NettyServerBuilder.forPort(port).addService(testService);
+    NettyServerBuilder serverBuilder = NettyServerBuilder.forPort(port)
+        .addService(testService)
+        .addService(ProtoReflectionService.newInstance());
     if (sslContext.isPresent()) {
       serverBuilder.sslContext(sslContext.get());
     }

--- a/src/main/java/me/dinowernli/grpc/polyglot/testing/TestUtils.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/testing/TestUtils.java
@@ -27,8 +27,7 @@ public class TestUtils {
     return Paths.get(".").toAbsolutePath();
   }
 
-  public static ImmutableList<String> makePolyglotCallArgs(
-      String endpoint, String protoRoot, String method) {
+  public static ImmutableList<String> makePolyglotCallArgs(String endpoint, String method) {
     return ImmutableList.<String>builder()
         .add(makeArgument("command", "call"))
         .add(makeArgument("endpoint", endpoint))

--- a/src/main/proto/BUILD
+++ b/src/main/proto/BUILD
@@ -8,13 +8,20 @@ java_proto_library(
 )
 
 java_proto_library(
+    name = "greeting_proto",
+    protos = ["greeting.proto"],
+)
+
+java_proto_library(
     name = "hello_proto_grpc",
     protos = ["hello.proto"],
+    proto_deps = [":greeting_proto"],
     with_grpc = True,
 )
 
 java_proto_library(
     name = "hello_proto",
     protos = ["hello.proto"],
+    proto_deps = [":greeting_proto"],
     with_grpc = False,
 )

--- a/src/main/proto/config.proto
+++ b/src/main/proto/config.proto
@@ -89,13 +89,16 @@ message OutputConfiguration {
   string file_path = 2;
 }
 
-// Contains the necessary information to locate .proto files for services and
-// analyze them by invoking protoc.
+// Contains the necessary information to locate .proto files for services.
 message ProtoConfiguration {
   // A root directory to scan for .proto files. All files found this way will
-  // be analyzed for service definitions.
+  // be analyzed for service definitions by invoking protoc.
   string proto_discovery_root = 1;
 
-  // Include paths used to resolve imports of the files being analyzed.
+  // Include paths used to resolve imports of the files being analyzed when
+  // resolving service definitions using protoc.
   repeated string include_paths = 2;
+
+  // If true, protos will first be resolved by reflection if applicable.
+  bool use_reflection = 3;
 }

--- a/src/main/proto/greeting.proto
+++ b/src/main/proto/greeting.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package polyglot;
+
+option java_outer_classname = "GreetingProto";
+
+message Greeting {
+  string message = 1;
+}

--- a/src/main/proto/hello.proto
+++ b/src/main/proto/hello.proto
@@ -4,12 +4,15 @@ package polyglot;
 
 option java_outer_classname = "HelloProto";
 
+import "src/main/proto/greeting.proto";
+
 message HelloRequest {
   string recipient = 1;
 }
 
 message HelloResponse {
   string message = 1;
+  Greeting greeting = 2;
 }
 
 service HelloService {

--- a/src/test/java/me/dinowernli/grpc/polyglot/config/CommandLineArgsTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/config/CommandLineArgsTest.java
@@ -51,6 +51,7 @@ public class CommandLineArgsTest {
         .add("--endpoint=somehost:1234")
         .add("--full_method=some.package/Method")
         .add("--proto_discovery_root=.")
+        .add("--use_reflection=true")
         .build();
     return CommandLineArgs.parse(allArgs.toArray(new String[0]));
   }

--- a/src/test/java/me/dinowernli/grpc/polyglot/integration/ClientServerIntegrationTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/integration/ClientServerIntegrationTest.java
@@ -72,6 +72,26 @@ public class ClientServerIntegrationTest {
     ImmutableList<String> args = ImmutableList.<String>builder()
         .addAll(makeArgs(serverPort, TestUtils.TESTING_PROTO_ROOT.toString(), TEST_UNARY_METHOD))
         .add(makeArgument("output_file_path", responseFilePath.toString()))
+        .add(makeArgument("use_reflection", "false"))
+        .build();
+    setStdinContents(MessageWriter.writeJsonStream(ImmutableList.of(REQUEST)));
+
+    // Run the full client.
+    me.dinowernli.grpc.polyglot.Main.main(args.toArray(new String[0]));
+
+    // Make sure we can parse the response from the file.
+    ImmutableList<TestResponse> responses = TestUtils.readResponseFile(responseFilePath);
+    assertThat(responses).hasSize(1);
+    assertThat(responses.get(0)).isEqualTo(TestServer.UNARY_SERVER_RESPONSE);
+  }
+
+  @Test
+  public void makesRoundTripUnary_WithReflection() throws Throwable {
+    int serverPort = testServer.getGrpcServerPort();
+    ImmutableList<String> args = ImmutableList.<String>builder()
+        .addAll(makeArgs(serverPort, TestUtils.TESTING_PROTO_ROOT.toString(), TEST_UNARY_METHOD))
+        .add(makeArgument("output_file_path", responseFilePath.toString()))
+        .add(makeArgument("use_reflection", "true"))
         .build();
     setStdinContents(MessageWriter.writeJsonStream(ImmutableList.of(REQUEST)));
 
@@ -90,6 +110,7 @@ public class ClientServerIntegrationTest {
     ImmutableList<String> args = ImmutableList.<String>builder()
         .addAll(makeArgs(serverPort, TestUtils.TESTING_PROTO_ROOT.toString(), TEST_STREAM_METHOD))
         .add(makeArgument("output_file_path", responseFilePath.toString()))
+        .add(makeArgument("use_reflection", "false"))
         .build();
     setStdinContents(MessageWriter.writeJsonStream(ImmutableList.of(REQUEST)));
 
@@ -108,6 +129,7 @@ public class ClientServerIntegrationTest {
         .addAll(makeArgs(
             serverPort, TestUtils.TESTING_PROTO_ROOT.toString(), TEST_CLIENT_STREAM_METHOD))
         .add(makeArgument("output_file_path", responseFilePath.toString()))
+        .add(makeArgument("use_reflection", "false"))
         .build();
     setStdinContents(MessageWriter.writeJsonStream(ImmutableList.of(REQUEST, REQUEST, REQUEST)));
 
@@ -126,6 +148,7 @@ public class ClientServerIntegrationTest {
         .addAll(makeArgs(
             serverPort, TestUtils.TESTING_PROTO_ROOT.toString(), TEST_BIDI_METHOD))
         .add(makeArgument("output_file_path", responseFilePath.toString()))
+        .add(makeArgument("use_reflection", "false"))
         .build();
     setStdinContents(MessageWriter.writeJsonStream(ImmutableList.of(REQUEST, REQUEST, REQUEST)));
 

--- a/src/test/java/me/dinowernli/grpc/polyglot/integration/TlsIntegrationTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/integration/TlsIntegrationTest.java
@@ -9,10 +9,10 @@ import java.util.Optional;
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import me.dinowernli.junit.TestClass;
 import me.dinowernli.grpc.polyglot.io.MessageWriter;
 import me.dinowernli.grpc.polyglot.testing.TestServer;
 import me.dinowernli.grpc.polyglot.testing.TestUtils;
+import me.dinowernli.junit.TestClass;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -64,10 +64,7 @@ public class TlsIntegrationTest {
   public void makesRoundTripUnary() throws Throwable {
     testServer = TestServer.createAndStart(Optional.of(TestServer.serverSslContextForTesting()));
     ImmutableList<String> args = ImmutableList.<String>builder()
-        .addAll(makeArgs(
-            testServer.getGrpcServerPort(),
-            TestUtils.TESTING_PROTO_ROOT.toString(),
-            TEST_UNARY_METHOD))
+        .addAll(makeArgs(testServer.getGrpcServerPort(), TEST_UNARY_METHOD))
         .add(makeArgument("output_file_path", responseFilePath.toString()))
         .add(makeArgument("tls_ca_cert_path", TestUtils.loadRootCaCert().getAbsolutePath()))
         .add(makeArgument("use_tls", "true"))
@@ -88,10 +85,7 @@ public class TlsIntegrationTest {
     testServer = TestServer.createAndStart(
         Optional.of(TestServer.serverSslContextWithClientCertsForTesting()));
     ImmutableList<String> args = ImmutableList.<String>builder()
-        .addAll(makeArgs(
-            testServer.getGrpcServerPort(),
-            TestUtils.TESTING_PROTO_ROOT.toString(),
-            TEST_UNARY_METHOD))
+        .addAll(makeArgs(testServer.getGrpcServerPort(), TEST_UNARY_METHOD))
         .add(makeArgument("output_file_path", responseFilePath.toString()))
         .add(makeArgument("tls_ca_cert_path", TestUtils.loadRootCaCert().getAbsolutePath()))
         .add(makeArgument("tls_client_cert_path", TestUtils.loadClientCert().getAbsolutePath()))
@@ -109,9 +103,8 @@ public class TlsIntegrationTest {
     assertThat(responses.get(0)).isEqualTo(TestServer.UNARY_SERVER_RESPONSE);
   }
 
-  private static ImmutableList<String> makeArgs(int port, String protoRoot, String method) {
-    return TestUtils.makePolyglotCallArgs(
-        Joiner.on(':').join("localhost", port), protoRoot, method);
+  private static ImmutableList<String> makeArgs(int port, String method) {
+    return TestUtils.makePolyglotCallArgs(Joiner.on(':').join("localhost", port), method);
   }
 
   private static void setStdinContents(String contents) {

--- a/src/tools/example/call-command-example-reflection.sh
+++ b/src/tools/example/call-command-example-reflection.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+POLYGLOT_PATH="src/main/java/me/dinowernli/grpc/polyglot"
+POLYGLOT_BIN="./bazel-bin/${POLYGLOT_PATH}/polyglot"
+
+if [ ! -f WORKSPACE ]; then
+    echo "Could not find WORKSPACE file - this must be run from the project root directory"
+    exit 1
+fi
+
+bazel build ${POLYGLOT_PATH} && \
+cat src/tools/example/request.pb.ascii | ${POLYGLOT_BIN}  \
+  --command=call \
+  --full_method=polyglot.HelloService/SayHello \
+  --endpoint=localhost:12345 \
+  --config_set_path=config.pb.json \
+  --deadline_ms=3000 \
+  $@

--- a/src/tools/example/call-command-example.sh
+++ b/src/tools/example/call-command-example.sh
@@ -16,4 +16,5 @@ cat src/tools/example/request.pb.ascii | ${POLYGLOT_BIN}  \
   --proto_discovery_root=./src/main/proto \
   --add_protoc_includes=. \
   --config_set_path=config.pb.json \
-  --deadline_ms=3000
+  --deadline_ms=3000 \
+  $@

--- a/third_party/grpc/BUILD
+++ b/third_party/grpc/BUILD
@@ -12,6 +12,7 @@ java_library(
         "@grpc_netty_artifact//jar",
         "@grpc_protobuf_artifact//jar",
         "@grpc_protobuf_lite_artifact//jar",
+        "@grpc_services_artifact//jar",
         "@grpc_stub_artifact//jar",
         "@io_netty_tcnative_boringssl_static//jar",
     ],


### PR DESCRIPTION
The new default behavior is to try resolving by reflection, and only invoke protoc as a fallback.

The behavior can be forced on/off with the --use_reflection=true|false flag.