### PR TITLE
Add GRPC Metadata support

### DIFF
--- a/src/main/java/me/dinowernli/grpc/polyglot/config/ConfigurationLoader.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/config/ConfigurationLoader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -136,6 +137,15 @@ public class ConfigurationLoader {
 
     overrides.tlsClientOverrideAuthority()
         .ifPresent(resultBuilder.getCallConfigBuilder()::setTlsClientOverrideAuthority);
+
+    overrides.metadata().ifPresent(metadata -> {
+      for (Map.Entry<String, String> keyValue : metadata.entries().asList()) {
+        resultBuilder.getCallConfigBuilder().addMetadataBuilder()
+            .setName(keyValue.getKey())
+            .setValue(keyValue.getValue())
+            .build();
+      }
+    });
 
     return resultBuilder.build();
   }

--- a/src/main/proto/config.proto
+++ b/src/main/proto/config.proto
@@ -32,7 +32,18 @@ message CallConfiguration {
   string tls_client_cert_path = 5;
   string tls_client_key_path = 6;
   string tls_client_override_authority = 7;
+
+  // Metadata to be included with the call.
+  // Entries will be appended to any existing metadata.
+  // Entries whose name already exists as a metadata entry will have the value appended to the values list.
+  repeated CallMetadataEntry metadata = 8;
 }
+
+message CallMetadataEntry {
+  string name = 1;
+  string value = 2;
+}
+
 
 // Holds the necessary parameters for adding authentication to requests using
 // Oauth2.
@@ -66,7 +77,7 @@ message OauthConfiguration {
     // the access token will be used to authenticate the request.
     RefreshTokenCredentials refresh_token_credentials = 1;
 
-    // If present, the access token will be used to authenticate the request.    
+    // If present, the access token will be used to authenticate the request.
     AccessTokenCredentials access_token_credentials = 2;
   }
 }
@@ -76,7 +87,7 @@ message OutputConfiguration {
   enum Destination {
     // Content is written to standard output.
     STDOUT = 0;
-  
+
     // Content is written to the execution log, i.e., to standard error.
     LOG = 1;
 

--- a/src/test/java/me/dinowernli/grpc/polyglot/config/CommandLineArgsTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/config/CommandLineArgsTest.java
@@ -2,10 +2,12 @@ package me.dinowernli.grpc.polyglot.config;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableMultimap;
 import me.dinowernli.junit.TestClass;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import org.junit.After;
 import org.junit.Before;
@@ -43,6 +45,24 @@ public class CommandLineArgsTest {
     CommandLineArgs params = parseArgs(ImmutableList.of(
         String.format("--add_protoc_includes=%s", tempFile1.toString())));
     assertThat(params.additionalProtocIncludes()).hasSize(1);
+  }
+
+  @Test
+  public void parseMetadata() {
+    CommandLineArgs params = parseArgs(ImmutableList.of(
+        String.format("--metadata=%s:%s,%s:%s,%s:%s", "key1", "value1", "key1", "value2", "key2", "value2")));
+
+
+    ImmutableMultimap<Object, Object> expectedResult = ImmutableMultimap.of("key1", "value1", "key1", "value2", "key2", "value2");
+    assertThat(params.metadata()).isEqualTo(Optional.of(expectedResult));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void parseMetadataWithKeyWithoutValue() {
+    CommandLineArgs params = parseArgs(ImmutableList.of(
+        String.format("--metadata=%s:%s,%s", "key1", "value1", "key2")));
+
+    params.metadata();
   }
 
   private static CommandLineArgs parseArgs(ImmutableList<String> args) {

--- a/src/test/java/me/dinowernli/grpc/polyglot/config/ConfigurationLoaderTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/config/ConfigurationLoaderTest.java
@@ -4,6 +4,7 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import me.dinowernli.junit.TestClass;
 import org.junit.After;
 import org.junit.Before;
@@ -82,6 +83,8 @@ public class ConfigurationLoaderTest {
     when(mockOverrides.tlsClientCertPath()).thenReturn(Optional.of(Paths.get("client_cert")));
     when(mockOverrides.tlsClientKeyPath()).thenReturn(Optional.of(Paths.get("client_key")));
     when(mockOverrides.tlsClientOverrideAuthority()).thenReturn(Optional.of("override_authority"));
+    ImmutableMultimap<String, String> metadata = ImmutableMultimap.of("key1", "value1", "key2", "value2");
+    when(mockOverrides.metadata()).thenReturn(Optional.of(metadata));
 
     Configuration config = ConfigurationLoader
         .forDefaultConfigSet()
@@ -97,6 +100,7 @@ public class ConfigurationLoaderTest {
     assertThat(callConfig.getTlsClientCertPath()).isEqualTo("client_cert");
     assertThat(callConfig.getTlsClientKeyPath()).isEqualTo("client_key");
     assertThat(callConfig.getTlsClientOverrideAuthority()).isEqualTo("override_authority");
+    assertThat(callConfig.getMetadataCount()).isEqualTo(2);
   }
 
   private static Configuration namedConfig(String name) {


### PR DESCRIPTION
Add new polyglot command line argument `--metadata` that allow users to
pass key:value entries that will be configured into GRPC Metadata
headers.

```sh
java -jar polyglot.jar --command=call --metadata=k1:v1,k2:v2 (...)
```

This fixes #42 and was made based on unmerged PR #50