### PR TITLE
Distinguish between input files and output files for command line params.

### DIFF
--- a/src/main/java/me/dinowernli/grpc/polyglot/config/CommandLineArgs.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/config/CommandLineArgs.java
@@ -147,12 +147,12 @@ public class CommandLineArgs {
 
   /** Returns the root of the directory tree in which to discover proto files. */
   public Optional<Path> protoDiscoveryRoot() {
-    return maybePath(protoDiscoveryRootArg);
+    return maybeInputPath(protoDiscoveryRootArg);
   }
 
   /** Returns the location in which to store the response proto. */
   public Optional<Path> outputFilePath() {
-    return maybePath(outputFilePathArg);
+    return maybeOutputPath(outputFilePathArg);
   }
 
   public Optional<Boolean> useTls() {
@@ -163,7 +163,7 @@ public class CommandLineArgs {
   }
 
   public Optional<Path> configSetPath() {
-    return maybePath(configSetPathArg);
+    return maybeInputPath(configSetPathArg);
   }
 
   public Optional<String> configName() {
@@ -171,15 +171,15 @@ public class CommandLineArgs {
   }
 
   public Optional<Path> tlsCaCertPath() {
-    return maybePath(tlsCaCertPath);
+    return maybeInputPath(tlsCaCertPath);
   }
 
   public Optional<Path> tlsClientCertPath() {
-    return maybePath(tlsClientCertPath);
+    return maybeInputPath(tlsClientCertPath);
   }
 
   public Optional<Path> tlsClientKeyPath() {
-    return maybePath(tlsClientKeyPath);
+    return maybeInputPath(tlsClientKeyPath);
   }
 
   public Optional<String> tlsClientOverrideAuthority() {
@@ -271,12 +271,18 @@ public class CommandLineArgs {
     return help != null && help;
   }
 
-  private static Optional<Path> maybePath(String rawPath) {
+  private static Optional<Path> maybeOutputPath(String rawPath) {
     if (rawPath == null) {
       return Optional.empty();
     }
     Path path = Paths.get(rawPath);
-    Preconditions.checkArgument(Files.exists(path), "File " + rawPath + " does not exist");
     return Optional.of(Paths.get(rawPath));
+  }
+
+  private static Optional<Path> maybeInputPath(String rawPath) {
+    return maybeOutputPath(rawPath).map(path -> {
+      Preconditions.checkArgument(Files.exists(path), "File " + rawPath + " does not exist");
+      return path;
+    });
   }
 }

--- a/src/test/java/me/dinowernli/grpc/polyglot/io/BUILD
+++ b/src/test/java/me/dinowernli/grpc/polyglot/io/BUILD
@@ -11,6 +11,7 @@ auto_java_test(
         "//src/main/java/me/dinowernli/grpc/polyglot/io",
         "//src/main/java/me/dinowernli/grpc/polyglot/io/testing",
         "//src/main/java/me/dinowernli/grpc/polyglot/testing",
+        "//src/main/proto:config_proto",
         "//src/main/proto/testing:test_service_proto",
         "//third_party/grpc",
         "//third_party/guava",

--- a/src/test/java/me/dinowernli/grpc/polyglot/io/OutputTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/io/OutputTest.java
@@ -1,0 +1,37 @@
+package me.dinowernli.grpc.polyglot.io;
+
+import com.google.common.io.Files;
+import me.dinowernli.junit.TestClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import polyglot.ConfigProto.OutputConfiguration;
+import polyglot.ConfigProto.OutputConfiguration.Destination;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Unit tests for {@link Output}. */
+@TestClass
+public class OutputTest {
+  @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void handlesMissingFile() throws Throwable {
+    Path filePath = Paths.get(tempFolder.getRoot().getAbsolutePath(), "some-file.txt");
+    Output output = Output.forConfiguration(OutputConfiguration.newBuilder()
+        .setDestination(Destination.FILE)
+        .setFilePath(filePath.toString())
+        .build());
+
+    output.write("foo");
+    output.close();
+
+    String line = Files.readFirstLine(new File(filePath.toUri()), Charset.defaultCharset());
+    assertThat(line).isEqualTo("foo");
+  }
+}

--- a/src/tools/check-buildifier.sh
+++ b/src/tools/check-buildifier.sh
@@ -10,7 +10,7 @@ fi
 
 
 bazel build @com_github_bazelbuild_buildtools//buildifier:buildifier
-RESULT=`find -name BUILD -or -name WORKSPACE | xargs bazel-bin/external/com_github_bazelbuild_buildtools/buildifier/buildifier $MODE -v`
+RESULT=`find . -name BUILD -or -name WORKSPACE | xargs bazel-bin/external/com_github_bazelbuild_buildtools/buildifier/buildifier $MODE -v`
 
 # In theory, buildifier should return a non-zero exit code in check mode if there are errors. From
 # staring at the buildifier code, it seems buildifier only returns the correct exit code for the


### PR DESCRIPTION
For input files, we must check that the file exists. For output files, this check would be incorrect.

This PR addresses issue https://github.com/grpc-ecosystem/polyglot/issues/89.

Drive-bys:
* Add a test for Output.java.
* Fix the buildifier script to work on mac as well as on linux.