### PR TITLE
Add support for all well-known-types, including "Any"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ In particular, it is not necessary to generate grpc classes for the service or t
 * Accepts request protos through stdin and can output responses to stdout to allow chaining.
 * Supports plain text connections as well as TLS.
 * Supports passing custom grpc metadata over the command line.
+* Supports all protobuf well-known-types, including fields of type "Any".
 
 ## Usage
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -7,6 +7,7 @@ Quick links:
 ## Upcoming release
 
 * Fixed a bug where Polyglot would bail out if the specified output file didn't already exist.
+* Added support for protobuf's well-known-types, including proper handling of "Any".
 
 ## 1.5.0
 

--- a/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
@@ -106,8 +106,8 @@ public class ServiceCall {
 
 
 
-    StreamObserver<DynamicMessage> streamObserver =
-        CompositeStreamObserver.of(new LoggingStatsWriter(), MessageWriter.create(output));
+    StreamObserver<DynamicMessage> streamObserver = CompositeStreamObserver.of(
+        new LoggingStatsWriter(), MessageWriter.create(output, registry));
     logger.info(String.format(
         "Making rpc with %d request(s) to endpoint [%s]", requestMessages.size(), hostAndPort));
     try {

--- a/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
@@ -7,6 +7,7 @@ import com.google.common.net.HostAndPort;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.Status;
@@ -95,8 +96,16 @@ public class ServiceCall {
     logger.info("Creating dynamic grpc client");
     DynamicGrpcClient dynamicClient = DynamicGrpcClient.create(methodDescriptor, channel);
 
+
+    TypeRegistry registry = TypeRegistry.newBuilder()
+        .add(serviceResolver.listMessageTypes())
+        .build();
     ImmutableList<DynamicMessage> requestMessages =
-        MessageReader.forStdin(methodDescriptor.getInputType()).read();
+        MessageReader.forStdin(methodDescriptor.getInputType(), registry).read();
+
+
+
+
     StreamObserver<DynamicMessage> streamObserver =
         CompositeStreamObserver.of(new LoggingStatsWriter(), MessageWriter.create(output));
     logger.info(String.format(

--- a/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/command/ServiceCall.java
@@ -96,16 +96,13 @@ public class ServiceCall {
     logger.info("Creating dynamic grpc client");
     DynamicGrpcClient dynamicClient = DynamicGrpcClient.create(methodDescriptor, channel);
 
-
+    // This collects all known types into a registry for resolution of potential "Any" types.
     TypeRegistry registry = TypeRegistry.newBuilder()
         .add(serviceResolver.listMessageTypes())
         .build();
+
     ImmutableList<DynamicMessage> requestMessages =
         MessageReader.forStdin(methodDescriptor.getInputType(), registry).read();
-
-
-
-
     StreamObserver<DynamicMessage> streamObserver = CompositeStreamObserver.of(
         new LoggingStatsWriter(), MessageWriter.create(output, registry));
     logger.info(String.format(

--- a/src/main/java/me/dinowernli/grpc/polyglot/io/MessageReader.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/io/MessageReader.java
@@ -37,7 +37,7 @@ public class MessageReader {
   }
 
   /** Creates a {@link MessageReader} which reads the messages from a file. */
-  private static MessageReader forFile(Path path, Descriptor descriptor, TypeRegistry registry) {
+  public static MessageReader forFile(Path path, Descriptor descriptor, TypeRegistry registry) {
     try {
       return new MessageReader(
           JsonFormat.parser().usingTypeRegistry(registry),

--- a/src/main/java/me/dinowernli/grpc/polyglot/io/MessageReader.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/io/MessageReader.java
@@ -1,17 +1,18 @@
 package me.dinowernli.grpc.polyglot.io;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /** A utility class which knows how to read proto files written using {@link MessageWriter}. */
 public class MessageReader {
@@ -20,19 +21,32 @@ public class MessageReader {
   private final BufferedReader bufferedReader;
   private final String source;
 
+  /** Creates a {@link MessageReader} which reads messages from stdin. */
+  public static MessageReader forStdin(Descriptor descriptor, TypeRegistry registry) {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+    return new MessageReader(
+        JsonFormat.parser().usingTypeRegistry(registry),
+        descriptor,
+        reader,
+        "STDIN");
+  }
+
   /** Creates a {@link MessageReader} which reads the messages from a file. */
   public static MessageReader forFile(Path path, Descriptor descriptor) {
+    return forFile(path, descriptor, TypeRegistry.getEmptyTypeRegistry());
+  }
+
+  /** Creates a {@link MessageReader} which reads the messages from a file. */
+  private static MessageReader forFile(Path path, Descriptor descriptor, TypeRegistry registry) {
     try {
       return new MessageReader(
-          JsonFormat.parser(), descriptor, Files.newBufferedReader(path), path.toString());
+          JsonFormat.parser().usingTypeRegistry(registry),
+          descriptor,
+          Files.newBufferedReader(path),
+          path.toString());
     } catch (IOException e) {
       throw new IllegalArgumentException("Unable to read file: " + path.toString(), e);
     }
-  }
-
-  public static MessageReader forStdin(Descriptor descriptor) {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
-    return new MessageReader(JsonFormat.parser(), descriptor, reader, "STDIN");
   }
 
   @VisibleForTesting

--- a/src/main/java/me/dinowernli/grpc/polyglot/io/MessageWriter.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/io/MessageWriter.java
@@ -3,6 +3,7 @@ package me.dinowernli.grpc.polyglot.io;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,8 +32,8 @@ public class MessageWriter<T extends Message> implements StreamObserver<T> {
    * Creates a new {@link MessageWriter} which writes the messages it sees to the supplied
    * {@link Output}.
    */
-  public static <T extends Message> MessageWriter<T> create(Output output) {
-    return new MessageWriter<T>(JsonFormat.printer(), output);
+  public static <T extends Message> MessageWriter<T> create(Output output, TypeRegistry registry) {
+    return new MessageWriter<>(JsonFormat.printer().usingTypeRegistry(registry), output);
   }
 
   /**
@@ -40,8 +41,18 @@ public class MessageWriter<T extends Message> implements StreamObserver<T> {
    * is represented as valid json, but not that the whole result is, itself, *not* valid json.
    */
   public static <M extends Message> String writeJsonStream(ImmutableList<M> messages) {
+    return writeJsonStream(messages, TypeRegistry.getEmptyTypeRegistry());
+  }
+
+  /**
+   * Returns the string representation of the stream of supplied messages. Each individual message
+   * is represented as valid json, but not that the whole result is, itself, *not* valid json.
+   */
+  public static <M extends Message> String writeJsonStream(
+      ImmutableList<M> messages, TypeRegistry registry) {
     ByteArrayOutputStream resultStream = new ByteArrayOutputStream();
-    MessageWriter<M> writer = MessageWriter.create(Output.forStream(new PrintStream(resultStream)));
+    MessageWriter<M> writer =
+        MessageWriter.create(Output.forStream(new PrintStream(resultStream)), registry);
     writer.writeAll(messages);
     return resultStream.toString();
   }

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/BUILD
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/BUILD
@@ -3,6 +3,9 @@ package(default_visibility = ["//visibility:public"])
 java_library(
     name = "protobuf",
     srcs = glob(["*.java"]),
+    data = [
+      "@com_google_protobuf//:well_known_protos",
+    ],
     deps = [
         "//src/main/proto:config_proto",
         "//third_party/google-oauth",

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/BUILD
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/BUILD
@@ -4,7 +4,7 @@ java_library(
     name = "protobuf",
     srcs = glob(["*.java"]),
     data = [
-      "@com_google_protobuf//:well_known_protos",
+        "@com_google_protobuf//:well_known_protos",
     ],
     deps = [
         "//src/main/proto:config_proto",

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/DynamicMessageMarshaller.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/DynamicMessageMarshaller.java
@@ -7,6 +7,7 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.ExtensionRegistryLite;
 
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import io.grpc.MethodDescriptor.Marshaller;
 
 /** A {@link Marshaller} for dynamic messages. */

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtocInvoker.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtocInvoker.java
@@ -27,18 +27,6 @@ public class ProtocInvoker {
   private static final Logger logger = LoggerFactory.getLogger(ProtocInvoker.class);
   private static final PathMatcher PROTO_MATCHER =
       FileSystems.getDefault().getPathMatcher("glob:**/*.proto");
-  private static final ImmutableSet<String> WELL_KNOWN_TYPE_FILES = ImmutableSet.of(
-      "any.proto",
-      "api.proto",
-      "descriptor.proto",
-      "duration.proto",
-      "empty.proto",
-      "field_mask.proto",
-      "source_context.proto",
-      "struct.proto",
-      "timestamp.proto",
-      "type.proto",
-      "wrappers.proto");
 
   private final ImmutableList<Path> protocIncludePaths;
   private final Path discoveryRoot;
@@ -173,7 +161,7 @@ public class ProtocInvoker {
   private static Path setupWellKnownTypes() throws IOException {
     Path tmpdir = Files.createTempDirectory("polyglot-well-known-types");
     Path protoDir = Files.createDirectories(Paths.get(tmpdir.toString(), "google", "protobuf"));
-    for (String file : WELL_KNOWN_TYPE_FILES) {
+    for (String file : WellKnownTypes.fileNames()) {
       Files.copy(
           ProtocInvoker.class.getResourceAsStream("/google/protobuf/" + file),
           Paths.get(protoDir.toString(), file));

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtocInvoker.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtocInvoker.java
@@ -99,7 +99,7 @@ public class ProtocInvoker {
       resultBuilder.add("-I" + path.toString());
     }
 
-    // Add the include path which makes sure that protoc find the well known types. Note that we
+    // Add the include path which makes sure that protoc finds the well known types. Note that we
     // add this *after* the user types above in case users want to provide their own well known
     // types.
     resultBuilder.add("-I" + wellKnownTypesInclude.toString());

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolver.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolver.java
@@ -1,21 +1,21 @@
 package me.dinowernli.grpc.polyglot.protobuf;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.MethodDescriptor;
 import com.google.protobuf.Descriptors.ServiceDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /** A locator used to read proto file descriptors and extract method definitions. */
 public class ServiceResolver {
@@ -47,6 +47,13 @@ public class ServiceResolver {
       serviceDescriptors.addAll(fileDescriptor.getServices());
     }
     return serviceDescriptors;
+  }
+
+  /** Lists all the known message types. */
+  public ImmutableSet<Descriptor> listMessageTypes() {
+    ImmutableSet.Builder<Descriptor> resultBuilder = ImmutableSet.builder();
+    fileDescriptors.forEach(d -> resultBuilder.addAll(d.getMessageTypes()));
+    return resultBuilder.build();
   }
 
   private ServiceResolver(Iterable<FileDescriptor> fileDescriptors) {

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/WellKnownTypes.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/WellKnownTypes.java
@@ -31,7 +31,24 @@ public class WellKnownTypes {
       TypeProto.getDescriptor().getFile().toProto(),
       WrappersProto.getDescriptor().getFile().toProto());
 
+  private static final ImmutableSet<String> FILES = ImmutableSet.of(
+      "any.proto",
+      "api.proto",
+      "descriptor.proto",
+      "duration.proto",
+      "empty.proto",
+      "field_mask.proto",
+      "source_context.proto",
+      "struct.proto",
+      "timestamp.proto",
+      "type.proto",
+      "wrappers.proto");
+
   public static ImmutableSet<FileDescriptorProto> descriptors() {
     return DESCRIPTORS;
+  }
+
+  public static ImmutableSet<String> fileNames() {
+    return FILES;
   }
 }

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/WellKnownTypes.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/WellKnownTypes.java
@@ -14,6 +14,9 @@ import com.google.protobuf.TimestampProto;
 import com.google.protobuf.TypeProto;
 import com.google.protobuf.WrappersProto;
 
+/**
+ * Central place to store information about the protobuf well-known-types.
+ */
 public class WellKnownTypes {
   private static final ImmutableSet<FileDescriptorProto> DESCRIPTORS = ImmutableSet.of(
       AnyProto.getDescriptor().getFile().toProto(),

--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/WellKnownTypes.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/WellKnownTypes.java
@@ -1,0 +1,34 @@
+package me.dinowernli.grpc.polyglot.protobuf;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.AnyProto;
+import com.google.protobuf.ApiProto;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DurationProto;
+import com.google.protobuf.EmptyProto;
+import com.google.protobuf.FieldMaskProto;
+import com.google.protobuf.SourceContextProto;
+import com.google.protobuf.StructProto;
+import com.google.protobuf.TimestampProto;
+import com.google.protobuf.TypeProto;
+import com.google.protobuf.WrappersProto;
+
+public class WellKnownTypes {
+  private static final ImmutableSet<FileDescriptorProto> DESCRIPTORS = ImmutableSet.of(
+      AnyProto.getDescriptor().getFile().toProto(),
+      ApiProto.getDescriptor().getFile().toProto(),
+      DescriptorProto.getDescriptor().getFile().toProto(),
+      DurationProto.getDescriptor().getFile().toProto(),
+      EmptyProto.getDescriptor().getFile().toProto(),
+      FieldMaskProto.getDescriptor().getFile().toProto(),
+      SourceContextProto.getDescriptor().getFile().toProto(),
+      StructProto.getDescriptor().getFile().toProto(),
+      TimestampProto.getDescriptor().getFile().toProto(),
+      TypeProto.getDescriptor().getFile().toProto(),
+      WrappersProto.getDescriptor().getFile().toProto());
+
+  public static ImmutableSet<FileDescriptorProto> descriptors() {
+    return DESCRIPTORS;
+  }
+}

--- a/src/main/java/me/dinowernli/grpc/polyglot/server/HelloServiceImpl.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/server/HelloServiceImpl.java
@@ -1,7 +1,10 @@
 package me.dinowernli.grpc.polyglot.server;
 
+import com.google.protobuf.Any;
+import com.google.protobuf.Timestamp;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import polyglot.HelloProto.AnyPayload;
 import polyglot.HelloProto.HelloRequest;
 import polyglot.HelloProto.HelloResponse;
 import polyglot.HelloServiceGrpc.HelloServiceImplBase;
@@ -14,6 +17,13 @@ public class HelloServiceImpl extends HelloServiceImplBase {
   public void sayHello(HelloRequest request, StreamObserver<HelloResponse> responseStream) {
     responseStream.onNext(HelloResponse.newBuilder()
         .setMessage("Hello, " + request.getRecipient())
+        .setTimestamp(Timestamp.newBuilder()
+            .setSeconds(1234)
+            .setNanos(5678)
+            .build())
+        .setAny(Any.pack(AnyPayload.newBuilder()
+            .setNumber(42)
+            .build()))
         .build());
     responseStream.onCompleted();
   }

--- a/src/main/java/me/dinowernli/grpc/polyglot/testing/TestServer.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/testing/TestServer.java
@@ -1,11 +1,8 @@
 package me.dinowernli.grpc.polyglot.testing;
 
-import java.io.IOException;
-import java.util.Optional;
-import java.util.Random;
-
 import com.google.common.base.Throwables;
-
+import com.google.protobuf.Any;
+import com.google.protobuf.Duration;
 import io.grpc.Server;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
@@ -15,7 +12,12 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import polyglot.test.TestProto.TestResponse;
+import polyglot.test.TestProto.TunnelMessage;
 import polyglot.test.TestServiceGrpc.TestServiceImplBase;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Random;
 
 /**
  * Holds a real grpc server for use in tests. The server returns canned responses for a fixed set of
@@ -25,11 +27,17 @@ public class TestServer {
   /** A response sent whenever the test server sees a request to its unary method. */
   public static final TestResponse UNARY_SERVER_RESPONSE = TestResponse.newBuilder()
       .setMessage("some fancy message")
+      .setAny(Any.pack(TunnelMessage.newBuilder()
+          .setNumber(12345)
+          .build()))
       .build();
 
   /** A response sent whenever the test server sees a request to its streaming method. */
   public static final TestResponse STREAMING_SERVER_RESPONSE = TestResponse.newBuilder()
       .setMessage("some other message")
+      .setDuration(Duration.newBuilder()
+          .setSeconds(12)
+          .setNanos(45))
       .build();
 
   /** A response sent whenever the test server sees a request to its client streaming method. */

--- a/src/main/java/me/dinowernli/grpc/polyglot/testing/TestUtils.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/testing/TestUtils.java
@@ -8,8 +8,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import me.dinowernli.grpc.polyglot.io.MessageReader;
 import polyglot.test.TestProto.TestResponse;
+import polyglot.test.TestProto.TunnelMessage;
 
 /** Utilities shared across tests. */
 public class TestUtils {
@@ -44,7 +46,10 @@ public class TestUtils {
   /** Attempts to read a response proto from the supplied file. */
   public static ImmutableList<TestResponse> readResponseFile(Path file)
       throws InvalidProtocolBufferException {
-    MessageReader reader = MessageReader.forFile(file, TestResponse.getDescriptor());
+    TypeRegistry registry = TypeRegistry.newBuilder()
+        .add(TunnelMessage.getDescriptor())
+        .build();
+    MessageReader reader = MessageReader.forFile(file, TestResponse.getDescriptor(), registry);
     ImmutableList<DynamicMessage> responses = reader.read();
 
     ImmutableList.Builder<TestResponse> resultBuilder = ImmutableList.builder();

--- a/src/main/proto/BUILD
+++ b/src/main/proto/BUILD
@@ -14,6 +14,12 @@ java_proto_library(
 
 java_proto_library(
     name = "hello_proto_grpc",
+    imports = [
+        "external/com_google_protobuf/src/",
+    ],
+    inputs = [
+        "@com_google_protobuf//:well_known_protos",
+    ],
     proto_deps = [":greeting_proto"],
     protos = ["hello.proto"],
     with_grpc = True,
@@ -21,6 +27,12 @@ java_proto_library(
 
 java_proto_library(
     name = "hello_proto",
+    imports = [
+        "external/com_google_protobuf/src/",
+    ],
+    inputs = [
+        "@com_google_protobuf//:well_known_protos",
+    ],
     proto_deps = [":greeting_proto"],
     protos = ["hello.proto"],
     with_grpc = False,

--- a/src/main/proto/hello.proto
+++ b/src/main/proto/hello.proto
@@ -4,6 +4,8 @@ package polyglot;
 
 option java_outer_classname = "HelloProto";
 
+import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "src/main/proto/greeting.proto";
 
 message HelloRequest {
@@ -13,6 +15,13 @@ message HelloRequest {
 message HelloResponse {
   string message = 1;
   Greeting greeting = 2;
+  google.protobuf.Any any = 3;
+  google.protobuf.Timestamp timestamp = 4;
+}
+
+// A message used as the payload of the "any" field above.
+message AnyPayload {
+  int32 number = 1;
 }
 
 service HelloService {

--- a/src/main/proto/testing/BUILD
+++ b/src/main/proto/testing/BUILD
@@ -4,6 +4,12 @@ package(default_visibility = ["//visibility:public"])
 
 java_proto_library(
     name = "test_service_proto",
+    imports = [
+        "external/com_google_protobuf/src/",
+    ],
+    inputs = [
+        "@com_google_protobuf//:well_known_protos",
+    ],
     proto_deps = [
         "//src/main/proto/testing/foo:foo_proto",
     ],
@@ -12,6 +18,12 @@ java_proto_library(
 
 java_proto_library(
     name = "test_service_proto_grpc",
+    imports = [
+        "external/com_google_protobuf/src/",
+    ],
+    inputs = [
+        "@com_google_protobuf//:well_known_protos",
+    ],
     proto_deps = [
         "//src/main/proto/testing/foo:foo_proto",
     ],

--- a/src/main/proto/testing/protobuf/standalone.proto
+++ b/src/main/proto/testing/protobuf/standalone.proto
@@ -2,7 +2,11 @@ syntax = "proto3";
 
 package polyglot.test.protoc;
 
+import "google/protobuf/any.proto";
+
 // This is a very simple file which is completely self-contained. It is used to
 // test the case where we pass no imports to the protoc invoker.
 message Standalone {
+    // This checks that the ProtocInvoker can do well-known-types.
+    google.protobuf.Any any = 1;
 }

--- a/src/main/proto/testing/test_service.proto
+++ b/src/main/proto/testing/test_service.proto
@@ -4,12 +4,14 @@ package polyglot.test;
 
 option java_outer_classname = "TestProto";
 
+//import "google/protobuf/any.proto";
 import "src/main/proto/testing/foo/foo.proto";
 
 message TestRequest {
   string message = 1;
   foo.Foo foo = 2;
   int32 number = 3;
+  //google.protobuf.Any any = 4;
 }
 
 message TestResponse {

--- a/src/main/proto/testing/test_service.proto
+++ b/src/main/proto/testing/test_service.proto
@@ -4,14 +4,14 @@ package polyglot.test;
 
 option java_outer_classname = "TestProto";
 
-//import "google/protobuf/any.proto";
+import "google/protobuf/any.proto";
 import "src/main/proto/testing/foo/foo.proto";
 
 message TestRequest {
   string message = 1;
   foo.Foo foo = 2;
   int32 number = 3;
-  //google.protobuf.Any any = 4;
+  google.protobuf.Any any = 4;
 }
 
 message TestResponse {

--- a/src/main/proto/testing/test_service.proto
+++ b/src/main/proto/testing/test_service.proto
@@ -5,17 +5,24 @@ package polyglot.test;
 option java_outer_classname = "TestProto";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
 import "src/main/proto/testing/foo/foo.proto";
 
 message TestRequest {
   string message = 1;
   foo.Foo foo = 2;
   int32 number = 3;
-  google.protobuf.Any any = 4;
 }
 
 message TestResponse {
   string message = 1;
+  google.protobuf.Any any = 2;
+  google.protobuf.Duration duration = 3;
+}
+
+// Used as a payload type for the any message above.
+message TunnelMessage {
+  int32 number = 1;
 }
 
 service TestService {

--- a/src/test/java/me/dinowernli/grpc/polyglot/command/BUILD
+++ b/src/test/java/me/dinowernli/grpc/polyglot/command/BUILD
@@ -6,6 +6,7 @@ auto_java_test(
     srcs = glob(["*.java"]),
     deps = [
         "//src/main/java/me/dinowernli/grpc/polyglot/command",
+        "//src/main/java/me/dinowernli/grpc/polyglot/protobuf",
         "//src/main/java/me/dinowernli/grpc/polyglot/testing",
         "//src/main/proto/testing:test_service_proto",
         "//src/main/proto/testing/foo:foo_proto",

--- a/src/test/java/me/dinowernli/grpc/polyglot/command/ServiceListTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/command/ServiceListTest.java
@@ -3,7 +3,9 @@ package me.dinowernli.grpc.polyglot.command;
 import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Any;
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
+import me.dinowernli.grpc.polyglot.protobuf.WellKnownTypes;
 import me.dinowernli.grpc.polyglot.testing.RecordingOutput;
 import me.dinowernli.junit.TestClass;
 import org.junit.Before;
@@ -19,6 +21,7 @@ public class ServiceListTest {
   private static FileDescriptorSet PROTO_FILE_DESCRIPTORS = FileDescriptorSet.newBuilder()
       .addFile(TestProto.getDescriptor().toProto())
       .addFile(FooProto.getDescriptor().toProto())
+      .addAllFile(WellKnownTypes.descriptors())
       .build();
 
   private static final String EXPECTED_SERVICE = "polyglot.test.TestService";

--- a/src/test/java/me/dinowernli/grpc/polyglot/io/MessageReaderTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/io/MessageReaderTest.java
@@ -9,11 +9,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import me.dinowernli.junit.TestClass;
 import me.dinowernli.grpc.polyglot.io.testing.TestData;
 import me.dinowernli.grpc.polyglot.testing.TestUtils;
 import org.junit.Test;
 import polyglot.test.TestProto.TestRequest;
+import polyglot.test.TestProto.TestResponse;
+import polyglot.test.TestProto.TunnelMessage;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -60,6 +63,19 @@ public class MessageReaderTest {
     reader = MessageReader.forFile(dataFilePath("request_with_primitives.pb.ascii"), DESCRIPTOR);
     ImmutableList<DynamicMessage> result = reader.read();
     assertThat(result).containsExactly(TestData.REQUEST_WITH_PRIMITIVE);
+  }
+
+  @Test
+  public void handlesAnyType() {
+    TypeRegistry registry = TypeRegistry.newBuilder()
+        .add(TunnelMessage.getDescriptor())
+        .build();
+    reader = MessageReader.forFile(
+        dataFilePath("response_any.pb.ascii"), TestResponse.getDescriptor(), registry);
+    ImmutableList<DynamicMessage> result = reader.read();
+
+    // If this doesn't crash, then we're happy.
+    assertThat(result).hasSize(1);
   }
 
   @Test

--- a/src/test/java/me/dinowernli/grpc/polyglot/io/MessageWriterTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/io/MessageWriterTest.java
@@ -5,22 +5,31 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.google.protobuf.Any;
+import com.google.protobuf.Duration;
+import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
 import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.TypeRegistry;
 import me.dinowernli.junit.TestClass;
 import me.dinowernli.grpc.polyglot.io.testing.TestData;
 import me.dinowernli.grpc.polyglot.testing.RecordingOutput;
 import me.dinowernli.grpc.polyglot.testing.TestUtils;
 import org.junit.Before;
 import org.junit.Test;
+import polyglot.test.TestProto.TestResponse;
+import polyglot.test.TestProto.TunnelMessage;
 
 import static com.google.common.truth.Truth.assertThat;
 
 /** Unit tests for {@link MessageWriter}. */
 @TestClass
 public class MessageWriterTest {
-  private static String TESTDATA_ROOT = Paths.get(TestUtils.getWorkspaceRoot().toString(),
+  private static final String TESTDATA_ROOT = Paths.get(TestUtils.getWorkspaceRoot().toString(),
       "src", "test", "java", "me", "dinowernli", "grpc", "polyglot", "io", "testdata").toString();
+  private static final TypeRegistry REGISTRY = TypeRegistry.newBuilder()
+      .add(TunnelMessage.getDescriptor())
+      .build();
 
   private MessageWriter<Message> writer;
   private RecordingOutput recordingOutput;
@@ -28,7 +37,7 @@ public class MessageWriterTest {
   @Before
   public void setUp() {
     recordingOutput = new RecordingOutput();
-    writer = new MessageWriter<>(JsonFormat.printer(), recordingOutput);
+    writer = new MessageWriter<>(JsonFormat.printer().usingTypeRegistry(REGISTRY), recordingOutput);
   }
 
   @Test
@@ -50,6 +59,25 @@ public class MessageWriterTest {
 
     assertThat(recordingOutput.getContentsAsString())
         .isEqualTo(loadTestFile("requests_multi.pb.ascii"));
+  }
+
+  @Test
+  public void writesMessageWithAny() throws Throwable {
+    TestResponse proto = TestResponse.newBuilder()
+        .setDuration(Duration.newBuilder()
+            .setSeconds(5678)
+            .setNanos(1234))
+        .setAny(Any.pack(TunnelMessage.newBuilder()
+            .setNumber(42)
+            .build()))
+        .build();
+
+    writer.onNext(DynamicMessage.newBuilder(proto).build());
+    writer.onCompleted();
+    recordingOutput.close();
+
+    assertThat(recordingOutput.getContentsAsString())
+        .isEqualTo(loadTestFile("response_any.pb.ascii"));
   }
 
   private static String loadTestFile(String filename) {

--- a/src/test/java/me/dinowernli/grpc/polyglot/io/testdata/response_any.pb.ascii
+++ b/src/test/java/me/dinowernli/grpc/polyglot/io/testdata/response_any.pb.ascii
@@ -1,0 +1,8 @@
+{
+  "any": {
+    "@type": "type.googleapis.com/polyglot.test.TunnelMessage",
+    "number": 42
+  },
+  "duration": "5678.000001234s"
+}
+

--- a/src/test/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolverTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolverTest.java
@@ -21,7 +21,7 @@ public class ServiceResolverTest {
   private ServiceResolver serviceResolver;
 
   @Before
-  public void setUp() throws Throwable {
+  public void setUp() {
     serviceResolver = ServiceResolver.fromFileDescriptorSet(PROTO_FILE_DESCRIPTORS);
   }
 

--- a/src/test/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolverTest.java
+++ b/src/test/java/me/dinowernli/grpc/polyglot/protobuf/ServiceResolverTest.java
@@ -1,11 +1,9 @@
 package me.dinowernli.grpc.polyglot.protobuf;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import me.dinowernli.junit.TestClass;
-
+import org.junit.Before;
+import org.junit.Test;
 import polyglot.test.TestProto;
 import polyglot.test.foo.FooProto;
 
@@ -16,6 +14,7 @@ public class ServiceResolverTest {
   private static FileDescriptorSet PROTO_FILE_DESCRIPTORS = FileDescriptorSet.newBuilder()
       .addFile(TestProto.getDescriptor().toProto())
       .addFile(FooProto.getDescriptor().toProto())
+      .addAllFile(WellKnownTypes.descriptors())
       .build();
 
   private ServiceResolver serviceResolver;

--- a/src/tools/bazel_0.2.2b-linux-x86_64.deb.sha256
+++ b/src/tools/bazel_0.2.2b-linux-x86_64.deb.sha256
@@ -1,1 +1,0 @@
-f81ae985eb03f3236be7e197f3c862dbc70a9807090efe0f67ddc6d59b3364ca  bazel_0.2.2b-linux-x86_64.deb


### PR DESCRIPTION
This PR adds support for protobuf's well-known-types, and, in particular, for fields of type "Any". Necessary parts:

* Plumb type registries into json readers and writers
* Point the invoked protoc binary at a copy of the well known proto definitions
* Add token well known types to all proto definitions for testing
* Fix up the integration tests