### PR TITLE
Auto-close Stream<Path> in ProtocInvoker

### DIFF
--- a/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtocInvoker.java
+++ b/src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtocInvoker.java
@@ -18,6 +18,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A utility class which facilitates invoking the protoc compiler on all proto files in a
@@ -144,8 +145,8 @@ public class ProtocInvoker {
   }
 
   private ImmutableSet<String> scanProtoFiles(Path protoRoot) throws ProtocInvocationException {
-    try {
-      return ImmutableSet.copyOf(Files.walk(protoRoot)
+    try (final Stream<Path> protoPaths = Files.walk(protoRoot)) {
+      return ImmutableSet.copyOf(protoPaths
           .filter(path -> PROTO_MATCHER.matches(path))
           .map(path -> path.toAbsolutePath().toString())
           .collect(Collectors.toSet()));


### PR DESCRIPTION
This fixes an "errorprone" check that Bazel 0.10.0 (and maybe older) enforces:

```
$ bazel build ...
INFO: Analysed 63 targets (0 packages loaded).
INFO: Found 63 targets...
ERROR: /.../polyglot/src/main/java/me/dinowernli/grpc/polyglot/protobuf/BUILD:3:1: Building src/main/java/me/dinowernli/grpc/polyglot/protobuf/libprotobuf.jar (5 source files) failed (Exit 1)
src/main/java/me/dinowernli/grpc/polyglot/protobuf/ProtocInvoker.java:148: error: [StreamResourceLeak] Streams that encapsulate a closeable resource should be closed using try-with-resources
      return ImmutableSet.copyOf(Files.walk(protoRoot)
                                           ^
    (see http://errorprone.info/bugpattern/StreamResourceLeak)
  Did you mean 'try (Stream<Path> stream = Files.walk(protoRoot)) {'?
INFO: Elapsed time: 0.868s, Critical Path: 0.61s
FAILED: Build did NOT complete successfully
```