### PR TITLE
Fixed README usage of --proto_discovery_root

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/grpc-ecosystem/polyglot.svg?branch=master)](https://travis-ci.org/grpc-ecosystem/polyglot)
 
 Polyglot is a grpc client which can talk to any grpc server. In order to make a call, the following are required:
-* A compiled Polyglot binary, 
+* A compiled Polyglot binary,
 * the .proto files for the service *or* grpc reflection enabled on the remote server,
 * and a request proto instance in text format.
 
@@ -33,20 +33,20 @@ The "Hello World" of using Polyglot is to make an rpc call. This can be done usi
 
 ```
 $ echo <json-request> | java -jar polyglot.jar \
+    --proto_discovery_root=<path> \
     call \
     --endpoint=<host>:<port> \
-    --full_method=<some.package.Service/doSomething> \
-    --proto_discovery_root=<path>
+    --full_method=<some.package.Service/doSomething>
 ```
 
 For stream requests double newlines `\n\n` are used to separate your json requests as follows:
 
 ```
 $ echo '<json-request-1> \n\n <json-request-2> ... \n\n <json-request-n>' | java -jar polyglot.jar \
+    --proto_discovery_root=<path> \
     call \
     --endpoint=<host>:<port> \
-    --full_method=<some.package.Service/doSomething> \
-    --proto_discovery_root=<path>
+    --full_method=<some.package.Service/doSomething>  
 ```
 
 For more invocation examples, see the [examples](https://github.com/grpc-ecosystem/polyglot/tree/master/src/tools/example) directory.
@@ -138,8 +138,8 @@ Polyglot supports printing a list of all the discovered services using the `list
 
 ```
 $ java -jar polyglot.jar \
-    list_services \
     --proto_discovery_root=<path> \
+    list_services
 ```
 
 The printed services can be filtered using `--service_filter=<service_name>` or `--method_filter=<method_name>`, and the `--with_message` flag can be used to also print the exact format of the requests.


### PR DESCRIPTION
When I ran the commands listed I get the follow error,

```
Exception in thread "main" java.lang.RuntimeException: Unable to parse command line flags
	at me.dinowernli.grpc.polyglot.Main.main(Main.java:33)
Caused by: java.lang.IllegalArgumentException: Unable to parse command line flags
	at me.dinowernli.grpc.polyglot.config.CommandLineArgs.parse(CommandLineArgs.java:151)
	at me.dinowernli.grpc.polyglot.Main.main(Main.java:31)
Caused by: com.beust.jcommander.ParameterException: Was passed main parameter '--proto_discovery_root' but no main parameter was defined in your arg class
	at com.beust.jcommander.JCommander.initMainParameterValue(JCommander.java:936)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:752)
	at com.beust.jcommander.JCommander.parse(JCommander.java:340)
	at com.beust.jcommander.JCommander.parseValues(JCommander.java:787)
	at com.beust.jcommander.JCommander.parse(JCommander.java:340)
	at com.beust.jcommander.JCommander.parse(JCommander.java:319)
```

However if I move the `--proto_discovery_root` prior to the command name it works, similar to the [examples](https://github.com/grpc-ecosystem/polyglot/tree/master/src/tools/example). I've updated the README to match that